### PR TITLE
Fix: broken github link.

### DIFF
--- a/src/views/Transparency.vue
+++ b/src/views/Transparency.vue
@@ -89,7 +89,7 @@
         href="https://en.wikipedia.org/wiki/MIT_License">MIT License.</a> The MIT license is a "permissive license,"
       meaning it imposes very few restrictions on downstream use. We're happy that our code has often been reused and
       repurposed, by both nonprofit and for-profit organizations. You can find the code for all our projects on <a
-        href="htthttps://github.com/ourresearch">GitHub.</a>
+        href="https://github.com/ourresearch">GitHub.</a>
     </p>
     <p>
       If OurResearch or GitHub were to become sufficiently evil, this GitHub-hosted code could be removed or


### PR DESCRIPTION
Github link had an extra "htt" infront of the link, causing the link to fail to load. 

Checked rest of the project - this seems to be the only occurrence of this issue.